### PR TITLE
feat: add post office data via India Post API

### DIFF
--- a/backend/.clinerules
+++ b/backend/.clinerules
@@ -1,0 +1,27 @@
+# StellaNova Backend AI Coding Guidelines
+
+You are an expert Go backend developer. You are contributing to the StellaNova project.
+
+## Tech Stack
+- Go 1.23+
+- Gin Web Framework
+- Standard Library `log/slog` for logging
+
+## Absolute Constraints
+1. **Dependencies:** You MUST NOT add or install any new Go modules (via `go get`) without explicitly asking the user first.
+2. **Testing Framework:** Use ONLY the standard Go `testing` package and `net/http/httptest`. DO NOT use third-party testing libraries like `testify`.
+
+## Architecture & Coding Patterns
+- **Clean Architecture:** Maintain strict boundaries. Router -> Handler -> Service -> Provider -> Utils. Do not skip layers.
+- **Interface-Driven Design:** Define interfaces for all major components (Providers, Services, Managers) before implementing the concrete structs. Accept interfaces in constructors, not concrete types.
+- **Constructors:** Use the `New[TypeName]` pattern for initialization (e.g., `NewEntitiesHandler`).
+- **Context:** Pass `context.Context` as the first parameter to every method that performs I/O or logging.
+- **Error Handling:** Return errors up the call stack. Do not panic. Return empty slices/nil instead of errors for "not found" scenarios.
+- **Logging:** Use `log/slog` exclusively. Always use context-aware methods (e.g., `logger.InfoContext`) and snake_case for keys (e.g., `slog.String("city", city)`).
+
+## Testing Patterns
+- Write table-driven tests for all new handlers, services, and utils.
+- Use manual mocking via structs (e.g., `type mockEntitiesService struct`) that implement the required interfaces. 
+
+## Documentation
+- Write GoDoc comments for all exported interfaces, structs, and functions. Explain the purpose and expected behavior of interface methods.

--- a/backend/internal/cities/all_providers_test.go
+++ b/backend/internal/cities/all_providers_test.go
@@ -135,6 +135,11 @@ func RunUniversalCityProviderTests(t *testing.T, cityName string) {
 			}
 
 			for _, entity := range entities {
+				// Skip Post Office entity as it uses external HTTP API, not GeoJSON
+				if entity.Name == "Post Office" {
+					continue
+				}
+
 				if entity.IsAvailable {
 					t.Errorf("Entity '%s' should not be available when all layers return nil", entity.Name)
 				}
@@ -181,6 +186,11 @@ func testLayerScenarios(t *testing.T, provider CityProvider, mock *InstrumentedM
 		}
 
 		for _, entity := range entities {
+			// Skip Post Office entity as it uses external HTTP API, not GeoJSON
+			if entity.Name == "Post Office" {
+				continue
+			}
+
 			if entity.IsAvailable {
 				t.Errorf("Entity '%s' should not be available with nil response", entity.Name)
 			}

--- a/backend/internal/cities/bengaluru.go
+++ b/backend/internal/cities/bengaluru.go
@@ -3,20 +3,57 @@ package cities
 import (
 	"backend/internal/models"
 	"backend/internal/utils"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"strings"
+	"time"
 )
+
+const indiaPostAPIURL = "https://dac.indiapost.gov.in/mypincode/home"
+const indiaPostNextAction = "7f86f11580f1032603e2574b88b30708b68ae17e9d"
+
+type indiaPostResponse struct {
+	Data    []indiaPostOffice `json:"data"`
+	Success bool              `json:"success"`
+}
+
+type indiaPostOffice struct {
+	OfficeName    string `json:"office_name"`
+	Pincode       string `json:"pincode"`
+	DivisionName  string `json:"division_name"`
+	RegionName    string `json:"region_name"`
+	CircleName    string `json:"circle_name"`
+	Taluk         string `json:"taluk"`
+	DistrictName  string `json:"district_name"`
+	StateName     string `json:"state_name"`
+	WorkingHours  string `json:"working_hours"`
+	ContactNumber string `json:"contact_number"`
+	OfficeType    string `json:"office_type"`
+	DeliveryStatus string `json:"delivery_status"`
+}
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
 
 type BengaluruProvider struct {
 	logger     *slog.Logger
 	geoManager utils.GeoJsonManagerInterface
+	httpClient httpClient
 }
 
 func NewBangaloreProvider(geoManager utils.GeoJsonManagerInterface, logger *slog.Logger) *BengaluruProvider {
 	return &BengaluruProvider{
 		logger:     logger,
 		geoManager: geoManager,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
 	}
 }
 
@@ -77,6 +114,10 @@ func (p *BengaluruProvider) GetEntities(ctx context.Context, lat, lng float64) (
 	}
 
 	if entity := p.getParliamentaryConstituencyEntity(ctx, lat, lng); entity != nil {
+		entities = append(entities, *entity)
+	}
+
+	if entity := p.getPostOfficeEntity(ctx, lat, lng); entity != nil {
 		entities = append(entities, *entity)
 	}
 
@@ -368,4 +409,209 @@ func (p *BengaluruProvider) getParliamentaryConstituencyEntity(ctx context.Conte
 		attributes, p.logger)
 
 	return &entity
+}
+
+func (p *BengaluruProvider) getPostOfficeEntity(ctx context.Context, lat, lng float64) *models.Entity {
+	offices, err := p.fetchIndiaPostOffices(ctx, lat, lng)
+	if err != nil {
+		p.logger.WarnContext(ctx, "failed to fetch post office data",
+			slog.Any("error", err),
+			slog.Float64("lat", lat),
+			slog.Float64("lng", lng),
+		)
+		entity := models.NewUnavailableEntity("Post Office",
+			"This information is unavailable for this address. This could be because the India Post API is temporarily unavailable.",
+			nil,
+		)
+		return &entity
+	}
+
+	if len(offices) == 0 {
+		p.logger.InfoContext(ctx, "no post offices found for location",
+			slog.Float64("lat", lat),
+			slog.Float64("lng", lng),
+		)
+		entity := models.NewUnavailableEntity("Post Office",
+			"No post office information found for this location.",
+			nil,
+		)
+		return &entity
+	}
+
+	var attributes []models.Attribute
+	for i, office := range offices {
+		attributes = append(attributes, extractPostOfficeAttributes(office, i)...)
+	}
+
+	entity := utils.BuildEntity(ctx, "Post Office",
+		"This information is unavailable for this address. This could be because the India Post API is temporarily unavailable.",
+		nil,
+		attributes, p.logger)
+
+	return &entity
+}
+
+func (p *BengaluruProvider) fetchIndiaPostOffices(ctx context.Context, lat, lng float64) ([]indiaPostOffice, error) {
+	payload := fmt.Sprintf("[[%f,%f]]", lat, lng)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, indiaPostAPIURL, bytes.NewBufferString(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Next-Action", indiaPostNextAction)
+	req.Header.Set("content-type", "text/plain")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	offices, err := parseNextJSStreamResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return offices, nil
+}
+
+func parseNextJSStreamResponse(body []byte) ([]indiaPostOffice, error) {
+	lines := strings.Split(string(body), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "1:") {
+			jsonStr := strings.TrimPrefix(line, "1:")
+
+			var response indiaPostResponse
+			if err := json.Unmarshal([]byte(jsonStr), &response); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+			}
+
+			if !response.Success {
+				return nil, fmt.Errorf("API returned success=false")
+			}
+
+			return response.Data, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no data line found in Next.js stream response")
+}
+
+func extractPostOfficeAttributes(office indiaPostOffice, index int) []models.Attribute {
+	var attributes []models.Attribute
+
+	prefix := ""
+	if index > 0 {
+		prefix = fmt.Sprintf(" (Office %d)", index+1)
+	}
+
+	if office.OfficeName != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("Office Name%s", prefix),
+			Value:   office.OfficeName,
+			IsFound: true,
+		})
+	}
+
+	if office.Pincode != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("PIN Code%s", prefix),
+			Value:   office.Pincode,
+			IsFound: true,
+		})
+	}
+
+	if office.DivisionName != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("Division%s", prefix),
+			Value:   office.DivisionName,
+			IsFound: true,
+		})
+	}
+
+	if office.RegionName != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("Region%s", prefix),
+			Value:   office.RegionName,
+			IsFound: true,
+		})
+	}
+
+	if office.CircleName != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("Circle%s", prefix),
+			Value:   office.CircleName,
+			IsFound: true,
+		})
+	}
+
+	if office.Taluk != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("Taluk%s", prefix),
+			Value:   office.Taluk,
+			IsFound: true,
+		})
+	}
+
+	if office.DistrictName != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("District%s", prefix),
+			Value:   office.DistrictName,
+			IsFound: true,
+		})
+	}
+
+	if office.StateName != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("State%s", prefix),
+			Value:   office.StateName,
+			IsFound: true,
+		})
+	}
+
+	if office.OfficeType != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("Office Type%s", prefix),
+			Value:   office.OfficeType,
+			IsFound: true,
+		})
+	}
+
+	if office.DeliveryStatus != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("Delivery Status%s", prefix),
+			Value:   office.DeliveryStatus,
+			IsFound: true,
+		})
+	}
+
+	if office.WorkingHours != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("Working Hours%s", prefix),
+			Value:   office.WorkingHours,
+			IsFound: true,
+		})
+	}
+
+	if office.ContactNumber != "" {
+		attributes = append(attributes, models.Attribute{
+			Name:    fmt.Sprintf("Contact Number%s", prefix),
+			Value:   office.ContactNumber,
+			IsFound: true,
+		})
+	}
+
+	return attributes
 }

--- a/backend/internal/cities/post_office_test.go
+++ b/backend/internal/cities/post_office_test.go
@@ -1,0 +1,411 @@
+package cities
+
+import (
+	"backend/internal/models"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// mockHTTPClient implements httpClient interface for testing
+type mockHTTPClient struct {
+	response    *http.Response
+	err         error
+	statusCode  int
+	body        string
+	requestBody string
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	// Capture request body for verification
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		m.requestBody = string(body)
+	}
+
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Body:       io.NopCloser(strings.NewReader(m.body)),
+	}, nil
+}
+
+func TestParseNextJSStreamResponse(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		expectError bool
+		expectCount int
+	}{
+		{
+			name: "valid response with single office",
+			body: `0:{"a":"$@1","f":"","b":"vE0mwr0TbQKy9EsanIL7Y"}
+1:{"data":[{"office_name":"Viveknagar S.O","pincode":"560047","division_name":"Bengaluru East","region_name":"Bangalore HQ","circle_name":"Karnataka","taluk":"Bangalore","district_name":"Bengaluru","state_name":"Karnataka","working_hours":"09:00-17:00","contact_number":"080-25301234","office_type":"S.O","delivery_status":"Delivery"}],"success":true}`,
+			expectError: false,
+			expectCount: 1,
+		},
+		{
+			name: "valid response with multiple offices",
+			body: `0:{"a":"$@1","f":"","b":"vE0mwr0TbQKy9EsanIL7Y"}
+1:{"data":[{"office_name":"Office 1","pincode":"560001"},{"office_name":"Office 2","pincode":"560002"}],"success":true}`,
+			expectError: false,
+			expectCount: 2,
+		},
+		{
+			name: "response with success=false",
+			body: `0:{"a":"$@1","f":"","b":"vE0mwr0TbQKy9EsanIL7Y"}
+1:{"data":[],"success":false}`,
+			expectError: true,
+			expectCount: 0,
+		},
+		{
+			name: "response with no data line",
+			body: `0:{"a":"$@1","f":"","b":"vE0mwr0TbQKy9EsanIL7Y"}`,
+			expectError: true,
+			expectCount: 0,
+		},
+		{
+			name: "response with malformed JSON",
+			body: `1:{invalid json}`,
+			expectError: true,
+			expectCount: 0,
+		},
+		{
+			name: "response with empty data array",
+			body: `1:{"data":[],"success":true}`,
+			expectError: false,
+			expectCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			offices, err := parseNextJSStreamResponse([]byte(tt.body))
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if len(offices) != tt.expectCount {
+					t.Errorf("expected %d offices, got %d", tt.expectCount, len(offices))
+				}
+			}
+		})
+	}
+}
+
+func TestExtractPostOfficeAttributes(t *testing.T) {
+	tests := []struct {
+		name            string
+		office          indiaPostOffice
+		index           int
+		expectMinAttrs  int
+		expectedNames   []string
+		expectedValues  map[string]string
+	}{
+		{
+			name: "fully populated office",
+			office: indiaPostOffice{
+				OfficeName:     "Viveknagar S.O",
+				Pincode:        "560047",
+				DivisionName:   "Bengaluru East",
+				RegionName:     "Bangalore HQ",
+				CircleName:     "Karnataka",
+				Taluk:          "Bangalore",
+				DistrictName:   "Bengaluru",
+				StateName:      "Karnataka",
+				WorkingHours:   "09:00-17:00",
+				ContactNumber:  "080-25301234",
+				OfficeType:     "S.O",
+				DeliveryStatus: "Delivery",
+			},
+			index:          0,
+			expectMinAttrs: 11,
+			expectedNames:  []string{"Office Name", "PIN Code", "Division", "State"},
+			expectedValues: map[string]string{
+				"Office Name": "Viveknagar S.O",
+				"PIN Code":    "560047",
+				"Division":    "Bengaluru East",
+			},
+		},
+		{
+			name: "minimally populated office",
+			office: indiaPostOffice{
+				OfficeName: "Test Office",
+				Pincode:    "560001",
+			},
+			index:          0,
+			expectMinAttrs: 2,
+			expectedNames:  []string{"Office Name", "PIN Code"},
+			expectedValues: map[string]string{
+				"Office Name": "Test Office",
+				"PIN Code":    "560001",
+			},
+		},
+		{
+			name: "second office with prefix",
+			office: indiaPostOffice{
+				OfficeName: "Second Office",
+				Pincode:    "560002",
+			},
+			index:          1,
+			expectMinAttrs: 2,
+			expectedNames:  []string{"Office Name (Office 2)", "PIN Code (Office 2)"},
+			expectedValues: map[string]string{
+				"Office Name (Office 2)": "Second Office",
+				"PIN Code (Office 2)":    "560002",
+			},
+		},
+		{
+			name:            "empty office",
+			office:          indiaPostOffice{},
+			index:           0,
+			expectMinAttrs:  0,
+			expectedNames:   []string{},
+			expectedValues:  map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := extractPostOfficeAttributes(tt.office, tt.index)
+
+			if len(attrs) < tt.expectMinAttrs {
+				t.Errorf("expected at least %d attributes, got %d", tt.expectMinAttrs, len(attrs))
+			}
+
+			// Check expected attribute names exist
+			attrNames := make(map[string]bool)
+			for _, attr := range attrs {
+				attrNames[attr.Name] = true
+				if !attr.IsFound {
+					t.Errorf("attribute '%s' should have IsFound=true", attr.Name)
+				}
+			}
+
+			for _, name := range tt.expectedNames {
+				if !attrNames[name] {
+					t.Errorf("expected attribute '%s' not found", name)
+				}
+			}
+
+			// Check expected values
+			for _, attr := range attrs {
+				if expectedVal, ok := tt.expectedValues[attr.Name]; ok {
+					if attr.Value != expectedVal {
+						t.Errorf("attribute '%s': expected value '%s', got '%s'", attr.Name, expectedVal, attr.Value)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetPostOfficeEntity(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	tests := []struct {
+		name           string
+		mockResponse   string
+		mockStatus     int
+		mockError      error
+		expectAvail    bool
+		expectAttrCnt  int
+		expectEntityNm string
+	}{
+		{
+			name: "successful single office",
+			mockResponse: `0:{"a":"$@1","f":"","b":"test"}
+1:{"data":[{"office_name":"Test S.O","pincode":"560047","division_name":"Bangalore East"}],"success":true}`,
+			mockStatus:     http.StatusOK,
+			expectAvail:    true,
+			expectAttrCnt:  3,
+			expectEntityNm: "Post Office",
+		},
+		{
+			name: "successful multiple offices",
+			mockResponse: `0:{"a":"$@1","f":"","b":"test"}
+1:{"data":[{"office_name":"Office 1","pincode":"560001"},{"office_name":"Office 2","pincode":"560002"}],"success":true}`,
+			mockStatus:     http.StatusOK,
+			expectAvail:    true,
+			expectAttrCnt:  4, // 2 attributes per office
+			expectEntityNm: "Post Office",
+		},
+		{
+			name:           "API returns error",
+			mockResponse:   "",
+			mockStatus:     http.StatusInternalServerError,
+			expectAvail:    false,
+			expectEntityNm: "Post Office",
+		},
+		{
+			name:           "API returns empty data",
+			mockResponse:   `1:{"data":[],"success":true}`,
+			mockStatus:     http.StatusOK,
+			expectAvail:    false,
+			expectEntityNm: "Post Office",
+		},
+		{
+			name:           "API returns success false",
+			mockResponse:   `1:{"data":[],"success":false}`,
+			mockStatus:     http.StatusOK,
+			expectAvail:    false,
+			expectEntityNm: "Post Office",
+		},
+		{
+			name:           "malformed response",
+			mockResponse:   `not a valid response`,
+			mockStatus:     http.StatusOK,
+			expectAvail:    false,
+			expectEntityNm: "Post Office",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockHTTPClient{
+				statusCode: tt.mockStatus,
+				body:       tt.mockResponse,
+				err:        tt.mockError,
+			}
+
+			provider := &BengaluruProvider{
+				logger:     logger,
+				geoManager: NewInstrumentedMockGeoJsonManager(),
+				httpClient: mockClient,
+			}
+
+			entity := provider.getPostOfficeEntity(ctx, 12.97, 77.59)
+
+			if entity == nil {
+				t.Fatal("expected entity, got nil")
+			}
+
+			if entity.Name != tt.expectEntityNm {
+				t.Errorf("expected entity name '%s', got '%s'", tt.expectEntityNm, entity.Name)
+			}
+
+			if entity.IsAvailable != tt.expectAvail {
+				t.Errorf("expected IsAvailable=%v, got %v", tt.expectAvail, entity.IsAvailable)
+			}
+
+			if tt.expectAvail && len(entity.Attributes) < tt.expectAttrCnt {
+				t.Errorf("expected at least %d attributes, got %d", tt.expectAttrCnt, len(entity.Attributes))
+			}
+
+			if !tt.expectAvail && entity.NotAvailableMessage == "" {
+				t.Error("unavailable entity should have NotAvailableMessage")
+			}
+		})
+	}
+}
+
+func TestGetPostOfficeEntity_RequestFormat(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockHTTPClient{
+		statusCode: http.StatusOK,
+		body:       `1:{"data":[{"office_name":"Test"}],"success":true}`,
+	}
+
+	provider := &BengaluruProvider{
+		logger:     logger,
+		geoManager: NewInstrumentedMockGeoJsonManager(),
+		httpClient: mockClient,
+	}
+
+	lat := 12.963492
+	lng := 77.613344
+
+	_ = provider.getPostOfficeEntity(ctx, lat, lng)
+
+	// Verify request body format
+	expectedPayload := "[[12.963492,77.613344]]"
+	if mockClient.requestBody != expectedPayload {
+		t.Errorf("expected request body '%s', got '%s'", expectedPayload, mockClient.requestBody)
+	}
+}
+
+func TestFetchIndiaPostOffices_ContextCancellation(t *testing.T) {
+	logger := slog.Default()
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Simulate context cancellation error
+	mockClient := &mockHTTPClient{
+		statusCode: http.StatusOK,
+		body:       `1:{"data":[],"success":true}`,
+		err:        context.Canceled,
+	}
+
+	provider := &BengaluruProvider{
+		logger:     logger,
+		geoManager: NewInstrumentedMockGeoJsonManager(),
+		httpClient: mockClient,
+	}
+
+	_, err := provider.fetchIndiaPostOffices(ctx, 12.97, 77.59)
+	if err == nil {
+		t.Error("expected error due to cancelled context")
+	}
+}
+
+func TestGetPostOfficeEntity_IntegrationWithGetEntities(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockHTTPClient{
+		statusCode: http.StatusOK,
+		body: `0:{"a":"$@1","f":"","b":"test"}
+1:{"data":[{"office_name":"Viveknagar S.O","pincode":"560047"}],"success":true}`,
+	}
+
+	mockGeoManager := NewInstrumentedMockGeoJsonManager()
+	mockGeoManager.SetMode(ModeNil) // Return nil for all GeoJSON queries
+
+	provider := &BengaluruProvider{
+		logger:     logger,
+		geoManager: mockGeoManager,
+		httpClient: mockClient,
+	}
+
+	entities, err := provider.GetEntities(ctx, 12.97, 77.59)
+	if err != nil {
+		t.Fatalf("GetEntities failed: %v", err)
+	}
+
+	// Find the Post Office entity
+	var postOfficeEntity *models.Entity
+	for i, e := range entities {
+		if e.Name == "Post Office" {
+			postOfficeEntity = &entities[i]
+			break
+		}
+	}
+
+	if postOfficeEntity == nil {
+		t.Fatal("Post Office entity not found in response")
+	}
+
+	if !postOfficeEntity.IsAvailable {
+		t.Error("Post Office entity should be available")
+	}
+
+	if len(postOfficeEntity.Attributes) == 0 {
+		t.Error("Post Office entity should have attributes")
+	}
+}

--- a/frontend/.clinerules
+++ b/frontend/.clinerules
@@ -1,0 +1,25 @@
+# StellaNova Frontend AI Coding Guidelines
+
+You are an expert React frontend developer. You are contributing to the StellaNova project.
+
+## Tech Stack
+- React 19
+- TypeScript (Strict mode)
+- Vite 7
+- Tailwind CSS v4
+- MapLibre GL & @vis.gl/react-google-maps
+
+## Absolute Constraints
+1. **Dependencies:** You MUST NOT add or install any new npm packages without explicitly asking the user first.
+2. **Testing:** The project does not currently have a testing framework set up. Do not generate `.test.ts` or `.spec.ts` files until instructed otherwise.
+3. **Styling:** Strictly use Tailwind CSS classes and the custom design tokens defined in `src/styles.css`. Do not write inline styles or create new CSS files.
+
+## Architecture & Coding Patterns
+- **Components:** Write function components with a default export at the bottom. Name files using PascalCase (e.g., `SidebarHeader.tsx`). Define a `[ComponentName]Props` type at the top of every file.
+- **State Management:** Use the established Context API pattern (`Provider` + custom hook like `useAppContext`). Local state belongs in components via `useState`.
+- **API Calls:** Keep API logic strictly separated. All fetch calls must go in `src/api.ts` and return standard Promises.
+- **Types:** Centralize all domain and global types in `src/types.d.ts` using `export type`.
+- **Hooks:** Extract reusable logic into custom hooks in the `src/hooks/` directory. Use `useCallback` for functions passed as props and `useMemo` for heavy computations or library instances.
+
+## Documentation
+- Write JSDoc comments for all exported types, Context definitions, and complex custom hooks. Keep internal component comments concise and focused on "why", not "what".

--- a/frontend/src/components/Introduction.tsx
+++ b/frontend/src/components/Introduction.tsx
@@ -4,8 +4,8 @@ function Introduction() {
       <section className="prose">
         <p>
           If you're a Bengaluru resident, you can use Civic Compass to identify
-          the GBA (BBMP), BDA, Revenue, BESCOM, BWSSB offices, and Police
-          stations for your area.
+          the GBA (BBMP), BDA, Revenue, BESCOM, BWSSB offices, Police
+          stations, and Post Offices for your area.
         </p>
 
         <p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "StellaNova",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Integrate India Post API to fetch post office information for locations in Bengaluru. Add HTTP client with 10s timeout for external API calls. Update tests to skip post office entity validation since it uses external HTTP API instead of GeoJSON layers like other entities.